### PR TITLE
Have `get_taxonomy_terms()` always return an array

### DIFF
--- a/inc/class-post.php
+++ b/inc/class-post.php
@@ -380,7 +380,7 @@ class Post {
 	 * Get the taxonomy terms for a post
 	 *
 	 * @param string $taxonomy
-	 * @return array|false
+	 * @return array
 	 */
 	protected function get_taxonomy_terms( $taxonomy ) {
 
@@ -388,7 +388,7 @@ class Post {
 		if ( $terms && ! is_wp_error( $terms ) ) {
 			return $terms;
 		} else {
-			return false;
+			return array();
 		}
 
 	}


### PR DESCRIPTION
Fixes #2
